### PR TITLE
Fix DisplayFileTest method name typo

### DIFF
--- a/java/src/test/java/demo/domain/DisplayFileTest.java
+++ b/java/src/test/java/demo/domain/DisplayFileTest.java
@@ -266,7 +266,7 @@ class DisplayFileTest {
         }
 
         @Test
-        void handelPathStartingWithTilda() {
+        void handlePathStartingWithTilde() {
             final String javaFile = """
                     package demo;
                     


### PR DESCRIPTION
## Summary
- fix a typo in the test method name

## Testing
- `cargo test` *(fails: failed to download `clap` due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6841529fd274833084909e9a8250a612