### PR TITLE
Fix field display when editing entries

### DIFF
--- a/editor/src/main/resources/templates/fragments/entry.html
+++ b/editor/src/main/resources/templates/fragments/entry.html
@@ -3,7 +3,7 @@
 <body>
 
 <th:block th:fragment="editEntry(entry)">
-    <li th:id="|row-${entry.id}|">
+    <li th:id="|row-${entry.id}|" hx-on="htmx:load:showFields(this.querySelector('select[name=type]'))">
         <form hx-post="/" hx-target="#entries" th:id="|form-${entry.id}|" hx-swap="beforeend">
             <input th:if="${entry}" type="hidden" name="id" th:value="${entry.id}"/>
             <select name="type" onchange="showFields(this)">

--- a/editor/src/test/java/demo/EditorIT.java
+++ b/editor/src/test/java/demo/EditorIT.java
@@ -30,7 +30,10 @@ class EditorIT {
         try (EditorWebApplication editor = EditorWebApplication.launch()) {
             editor.openEditorPage()
                     .clickOnElementAtIndex(0, "> button[name=edit]")
-                    .assertElementAtIndexVisible(0, "> form div.Heading");
+                    .assertElementAtIndexVisible(0, "> form > select[name=type]")
+                    .assertElementAtIndexVisible(0, "> form > div#fields select[name=level]")
+                    .assertElementAtIndexVisible(0, "> form > div#fields input[name=title]")
+            ;
         }
     }
 }

--- a/editor/src/test/java/demo/EditorIT.java
+++ b/editor/src/test/java/demo/EditorIT.java
@@ -24,4 +24,13 @@ class EditorIT {
                     .assertElementAtIndexContains(0, "> h2", "Test Heading");
         }
     }
+
+    @Test
+    void fieldsVisibleWhenEditingHeadingEntry() {
+        try (EditorWebApplication editor = EditorWebApplication.launch()) {
+            editor.openEditorPage()
+                    .clickOnElementAtIndex(0, "> button[name=edit]")
+                    .assertElementAtIndexVisible(0, "> form div.Heading");
+        }
+    }
 }

--- a/editor/src/test/java/demo/EditorWebApplication.java
+++ b/editor/src/test/java/demo/EditorWebApplication.java
@@ -3,6 +3,7 @@ package demo;
 import demo.rest.EntryType;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.support.ui.Select;
@@ -97,6 +98,14 @@ public class EditorWebApplication implements AutoCloseable {
 
     public EditorWebApplication assertElementAtIndexContains(final int index, final String cssSelector, final String expectedContent) {
         return assertContainsText("ul#entries > li:nth-of-type(" + (index + 1) + ") " + cssSelector, expectedContent);
+    }
+
+    public EditorWebApplication assertElementAtIndexVisible(final int index, final String cssSelector) {
+        final WebElement element = driver.findElement(By.cssSelector("ul#entries > li:nth-of-type(" + (index + 1) + ") " + cssSelector));
+        if (!element.isDisplayed()) {
+            throw new AssertionError("Element '" + cssSelector + "' at index " + index + " is not visible");
+        }
+        return this;
     }
 
     public EditorWebApplication assertContainsText(final String cssSelector, final String expectedContent) {


### PR DESCRIPTION
## Summary
- display relevant fields immediately when an entry is edited
- add helper in test harness to assert element visibility
- add integration test covering edit field visibility

## Testing
- `./mvnw -q test` *(fails: Failed to fetch maven)*

------
https://chatgpt.com/codex/tasks/task_e_687e9893b8a88330a6a2768b8656dcc6