### PR TITLE
Add optional display file fields

### DIFF
--- a/editor/pom.xml
+++ b/editor/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.3</version>
+        <version>3.5.4</version>
         <relativePath/>
     </parent>
 

--- a/editor/src/main/java/demo/rest/AddEntryAfterTo.java
+++ b/editor/src/main/java/demo/rest/AddEntryAfterTo.java
@@ -9,8 +9,32 @@ public record AddEntryAfterTo(
     public EntryTo toNewEntry() {
         return switch (type) {
             case Heading ->
-                    new EntryTo(UUID.randomUUID(), type, null, null, null, HeadingLevel.H2, "Heading...", null);
-            default -> new EntryTo(UUID.randomUUID(), type, null, null, null, null, null, null);
+                    new EntryTo(
+                            UUID.randomUUID(),
+                            type,
+                            null,
+                            null,
+                            null,
+                            null,
+                            null,
+                            null,
+                            null,
+                            HeadingLevel.H2,
+                            "Heading...",
+                            null);
+            default -> new EntryTo(
+                            UUID.randomUUID(),
+                            type,
+                            null,
+                            null,
+                            null,
+                            null,
+                            null,
+                            null,
+                            null,
+                            null,
+                            null,
+                            null);
         };
     }
 }

--- a/editor/src/main/java/demo/rest/EditorController.java
+++ b/editor/src/main/java/demo/rest/EditorController.java
@@ -58,6 +58,17 @@ public final class EditorController {
         return "fragments/entry :: renderEntry";
     }
 
+    @PostMapping("/edit")
+    public String update(final EntryTo entry, final Model model) {
+        /* TODO: Add validation */
+        final int index = indexOfEntry(entry.id())
+                .orElseThrow(() -> new IllegalArgumentException("Entry with id " + entry.id() + " was not found"));
+
+        entries.set(index, entry);
+        model.addAttribute("entry", entry);
+        return "fragments/entry :: renderEntry";
+    }
+
     @GetMapping("/edit")
     public String edit(final @RequestParam("id") UUID id, final Model model) {
         final EntryTo entry = findEntryWithId(id)

--- a/editor/src/main/java/demo/rest/EntryTo.java
+++ b/editor/src/main/java/demo/rest/EntryTo.java
@@ -8,15 +8,43 @@ public record EntryTo(
         String comments,
         String commands,
         String path,
+        String contentType,
+        Integer fromLine,
+        Integer numberOfLines,
+        Integer indent,
         HeadingLevel level,
         String title,
         String contents) {
 
     public static EntryTo heading(final HeadingLevel level, final String title) {
-        return new EntryTo(UUID.randomUUID(), EntryType.Heading, null, null, null, level, title, null);
+        return new EntryTo(
+                UUID.randomUUID(),
+                EntryType.Heading,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                level,
+                title,
+                null);
     }
 
     public EntryTo(final EntryType type) {
-        this(UUID.randomUUID(), type, null, null, null, null, null, null);
+        this(
+                UUID.randomUUID(),
+                type,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null);
     }
 }

--- a/editor/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/editor/src/main/resources/META-INF/native-image/reflect-config.json
@@ -28,6 +28,10 @@
           "java.lang.String",
           "java.lang.String",
           "java.lang.String",
+          "java.lang.String",
+          "java.lang.Integer",
+          "java.lang.Integer",
+          "java.lang.Integer",
           "demo.rest.HeadingLevel",
           "java.lang.String",
           "java.lang.String"
@@ -51,6 +55,22 @@
       },
       {
         "name": "path",
+        "parameterTypes": []
+      },
+      {
+        "name": "contentType",
+        "parameterTypes": []
+      },
+      {
+        "name": "fromLine",
+        "parameterTypes": []
+      },
+      {
+        "name": "numberOfLines",
+        "parameterTypes": []
+      },
+      {
+        "name": "indent",
         "parameterTypes": []
       },
       {

--- a/editor/src/main/resources/templates/fragments/entry.html
+++ b/editor/src/main/resources/templates/fragments/entry.html
@@ -4,7 +4,7 @@
 
 <th:block th:fragment="editEntry(entry)">
     <li th:id="|row-${entry.id}|" hx-on="htmx:load:showFields(this.querySelector('select[name=type]'))">
-        <form hx-post="/" hx-target="#entries" th:id="|form-${entry.id}|" hx-swap="beforeend">
+        <form hx-post="/edit" hx-target="closest li" th:id="|form-${entry.id}|" hx-swap="outerHTML">
             <input th:if="${entry}" type="hidden" name="id" th:value="${entry.id}"/>
             <select name="type" onchange="showFields(this)">
                 <option th:each="type : ${T(demo.rest.EntryType).values()}"
@@ -46,7 +46,7 @@
                 </div>
             </div>
 
-            <button name="submit" type="submit">Update</button>
+            <button name="update" type="submit">Update</button>
             <button
                     name="cancel"
                     th:hx-get="@{/{id}(id=${entry.id})}"

--- a/editor/src/main/resources/templates/fragments/entry.html
+++ b/editor/src/main/resources/templates/fragments/entry.html
@@ -24,10 +24,15 @@
                 </div>
 
                 <div class="field DisplayFile" style="display:none">
+                    <label>File Path</label>
                     <input type="text" name="path" placeholder="File path" th:value="${entry.path}"/>
+                    <label>Content Type</label>
                     <input type="text" name="contentType" placeholder="Content type" th:value="${entry.contentType}"/>
+                    <label>From line number (1 based)</label>
                     <input type="text" name="fromLine" placeholder="From line" th:value="${entry.fromLine}"/>
+                    <label>Number of lines</label>
                     <input type="text" name="numberOfLines" placeholder="Number of lines" th:value="${entry.numberOfLines}"/>
+                    <label>Indent</label>
                     <input type="text" name="indent" placeholder="Indent" th:value="${entry.indent}"/>
                 </div>
 

--- a/editor/src/main/resources/templates/fragments/entry.html
+++ b/editor/src/main/resources/templates/fragments/entry.html
@@ -25,6 +25,10 @@
 
                 <div class="field DisplayFile" style="display:none">
                     <input type="text" name="path" placeholder="File path" th:value="${entry.path}"/>
+                    <input type="text" name="contentType" placeholder="Content type" th:value="${entry.contentType}"/>
+                    <input type="text" name="fromLine" placeholder="From line" th:value="${entry.fromLine}"/>
+                    <input type="text" name="numberOfLines" placeholder="Number of lines" th:value="${entry.numberOfLines}"/>
+                    <input type="text" name="indent" placeholder="Indent" th:value="${entry.indent}"/>
                 </div>
 
                 <div class="field Heading" style="display:none">

--- a/editor/src/test/java/demo/EditorIT.java
+++ b/editor/src/test/java/demo/EditorIT.java
@@ -15,11 +15,12 @@ class EditorIT {
     }
 
     @Test
-    void editFirstHeadingEntry() {
+    void editAndCancelFirstHeadingEntry() {
         try (EditorWebApplication editor = EditorWebApplication.launch()) {
             editor.openEditorPage()
                     .assertElementAtIndexContains(0, "> h2", "Test Heading")
                     .clickOnElementAtIndex(0, "> button[name=edit]")
+                    .waitForElementToBeVisible(0, "> form > button[name=cancel]")
                     .clickOnElementAtIndex(0, "> form > button[name=cancel]")
                     .assertElementAtIndexContains(0, "> h2", "Test Heading");
         }
@@ -30,10 +31,23 @@ class EditorIT {
         try (EditorWebApplication editor = EditorWebApplication.launch()) {
             editor.openEditorPage()
                     .clickOnElementAtIndex(0, "> button[name=edit]")
+                    .waitForElementToBeVisible(0, "> form > select[name=type]")
                     .assertElementAtIndexVisible(0, "> form > select[name=type]")
                     .assertElementAtIndexVisible(0, "> form > div#fields select[name=level]")
                     .assertElementAtIndexVisible(0, "> form > div#fields input[name=title]")
             ;
+        }
+    }
+
+    @Test
+    void updateFirstHeadingEntry() {
+        try (EditorWebApplication editor = EditorWebApplication.launch()) {
+            editor.openEditorPage()
+                    .clickOnElementAtIndex(0, "> button[name=edit]")
+                    .waitForElementToBeVisible(0, "> form input[name=title]")
+                    .setInputValueAtIndex(0, "> form input[name=title]", "Updated Heading")
+                    .clickOnElementAtIndex(0, "> form > button[name=update]")
+                    .assertElementAtIndexContains(0, "> h2", "Updated Heading");
         }
     }
 }


### PR DESCRIPTION
## Summary
- support specifying additional DisplayFile settings in EntryTo
- expose extra DisplayFile fields in the HTML form
- update reflection configuration for EntryTo

## Testing
- `./mvnw -q test` *(fails: Failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6883afbb849083309d2a606c7f9da622