### PR TITLE
Implement entry update and add integration test

### DIFF
--- a/editor/src/main/java/demo/rest/EditorController.java
+++ b/editor/src/main/java/demo/rest/EditorController.java
@@ -58,6 +58,17 @@ public final class EditorController {
         return "fragments/entry :: renderEntry";
     }
 
+    @PostMapping("/edit")
+    public String update(final EntryTo entry, final Model model) {
+        /* TODO: Add validation */
+        final int index = indexOfEntry(entry.id())
+                .orElseThrow(() -> new IllegalArgumentException("Entry with id " + entry.id() + " was not found"));
+
+        entries.set(index, entry);
+        model.addAttribute("entry", entry);
+        return "fragments/entry :: renderEntry";
+    }
+
     @GetMapping("/edit")
     public String edit(final @RequestParam("id") UUID id, final Model model) {
         final EntryTo entry = findEntryWithId(id)

--- a/editor/src/main/resources/templates/fragments/entry.html
+++ b/editor/src/main/resources/templates/fragments/entry.html
@@ -4,7 +4,7 @@
 
 <th:block th:fragment="editEntry(entry)">
     <li th:id="|row-${entry.id}|" hx-on="htmx:load:showFields(this.querySelector('select[name=type]'))">
-        <form hx-post="/" hx-target="#entries" th:id="|form-${entry.id}|" hx-swap="beforeend">
+        <form hx-post="/edit" hx-target="closest li" th:id="|form-${entry.id}|" hx-swap="outerHTML">
             <input th:if="${entry}" type="hidden" name="id" th:value="${entry.id}"/>
             <select name="type" onchange="showFields(this)">
                 <option th:each="type : ${T(demo.rest.EntryType).values()}"

--- a/editor/src/test/java/demo/EditorIT.java
+++ b/editor/src/test/java/demo/EditorIT.java
@@ -36,4 +36,15 @@ class EditorIT {
             ;
         }
     }
+
+    @Test
+    void updateHeadingEntry() {
+        try (EditorWebApplication editor = EditorWebApplication.launch()) {
+            editor.openEditorPage()
+                    .clickOnElementAtIndex(0, "> button[name=edit]")
+                    .setInputValueAtIndex(0, "> form input[name=title]", "Updated Heading")
+                    .clickOnElementAtIndex(0, "> form > button[name=submit]")
+                    .assertElementAtIndexContains(0, "> h2", "Updated Heading");
+        }
+    }
 }

--- a/editor/src/test/java/demo/EditorWebApplication.java
+++ b/editor/src/test/java/demo/EditorWebApplication.java
@@ -96,6 +96,13 @@ public class EditorWebApplication implements AutoCloseable {
         return this;
     }
 
+    public EditorWebApplication setInputValueAtIndex(final int index, final String cssSelector, final String value) {
+        final WebElement element = driver.findElement(By.cssSelector("ul#entries > li:nth-of-type(" + (index + 1) + ") " + cssSelector));
+        element.clear();
+        element.sendKeys(value);
+        return this;
+    }
+
     public EditorWebApplication assertElementAtIndexContains(final int index, final String cssSelector, final String expectedContent) {
         return assertContainsText("ul#entries > li:nth-of-type(" + (index + 1) + ") " + cssSelector, expectedContent);
     }


### PR DESCRIPTION
## Summary
- enable updating entries in `EditorController`
- adjust edit form to POST to `/edit`
- add helper to modify inputs in `EditorWebApplication`
- test updating a heading entry in `EditorIT`

## Testing
- `mvn -q -pl editor -am test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6883b56733ec83308c891ee5c7b81ec6