### PR TITLE
Add delete entry support

### DIFF
--- a/editor/src/main/java/demo/rest/EditorController.java
+++ b/editor/src/main/java/demo/rest/EditorController.java
@@ -5,6 +5,7 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.*;
@@ -75,6 +76,14 @@ public final class EditorController {
                 .orElseThrow(() -> new IllegalArgumentException("Entry with id " + id + " was not found"));
         model.addAttribute("entry", entry);
         return "fragments/entry :: editEntry";
+    }
+
+    @DeleteMapping("/delete")
+    public String delete(final @RequestParam("id") UUID id) {
+        final int index = indexOfEntry(id)
+                .orElseThrow(() -> new IllegalArgumentException("Entry with id " + id + " was not found"));
+        entries.remove(index);
+        return "fragments/entry :: empty";
     }
 
     private Optional<EntryTo> findEntryWithId(final UUID entryId) {

--- a/editor/src/main/resources/templates/fragments/entry.html
+++ b/editor/src/main/resources/templates/fragments/entry.html
@@ -102,6 +102,14 @@
             hx-include="closest li">
         Edit
     </button>
+    <button
+            name="delete"
+            hx-delete="/delete"
+            hx-target="closest li"
+            hx-swap="delete"
+            hx-include="closest li">
+        Delete
+    </button>
     <select name="type"
             hx-post="/after"
             hx-trigger="change"
@@ -111,5 +119,7 @@
         <option th:each="type : ${T(demo.rest.EntryType).values()}" th:value="${type}" th:text="${type}"></option>
     </select>
 </th:block>
+
+<th:block th:fragment="empty"></th:block>
 </body>
 </html>

--- a/editor/src/test/java/demo/EditorIT.java
+++ b/editor/src/test/java/demo/EditorIT.java
@@ -48,4 +48,15 @@ class EditorIT {
                     .assertTitleContains("Updated Heading");
         }
     }
+
+    @Test
+    void deleteSecondEntry() {
+        try (EditorWebApplication editor = EditorWebApplication.launch()) {
+            editor.openEditorPage()
+                    .row(1)
+                    .clickDeleteButton()
+                    .row(1)
+                    .assertContains("DisplayFile");
+        }
+    }
 }

--- a/editor/src/test/java/demo/EditorWebApplication.java
+++ b/editor/src/test/java/demo/EditorWebApplication.java
@@ -193,6 +193,11 @@ public class EditorWebApplication implements AutoCloseable {
             return new EditForm(this);
         }
 
+        public Row clickDeleteButton() {
+            application.clickOnElementAtIndex(index, "> button[name=delete]");
+            return this;
+        }
+
         private Row waitForElementToBeVisible(final String cssSelector) {
             application.waitForElementToBeVisible(index, cssSelector);
             return this;
@@ -215,6 +220,11 @@ public class EditorWebApplication implements AutoCloseable {
 
         private Row assertElementContains(final String cssSelector, final String expected) {
             application.assertElementAtIndexContains(index, cssSelector, expected);
+            return this;
+        }
+
+        public Row assertContains(final String expected) {
+            application.assertContainsText("ul#entries > li:nth-of-type(" + (index + 1) + ")", expected);
             return this;
         }
 

--- a/editor/src/test/java/demo/EditorWebApplication.java
+++ b/editor/src/test/java/demo/EditorWebApplication.java
@@ -193,9 +193,9 @@ public class EditorWebApplication implements AutoCloseable {
             return new EditForm(this);
         }
 
-        public Row clickDeleteButton() {
+        public EditorWebApplication clickDeleteButton() {
             application.clickOnElementAtIndex(index, "> button[name=delete]");
-            return this;
+            return application;
         }
 
         private Row waitForElementToBeVisible(final String cssSelector) {


### PR DESCRIPTION
## Summary
- add a button in the entry fragment to delete rows
- serve an empty fragment after deletion
- support deletion in the controller
- extend test helpers and add an integration test for deleting
- switch deletion endpoint to HTTP DELETE

## Testing
- `mvn -q -pl editor test` *(fails: Non-resolvable parent POM)*


------
https://chatgpt.com/codex/tasks/task_e_688734a1c38083308fd9ab364b7346fd