### PR TITLE
Enable opening playbooks by path with validation

### DIFF
--- a/editor/src/main/resources/META-INF/native-image/reachability-metadata.json
+++ b/editor/src/main/resources/META-INF/native-image/reachability-metadata.json
@@ -362,6 +362,40 @@
       ]
     },
     {
+      "type": "demo.service.HtmlConverterService",
+      "allDeclaredFields": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "demo.service.MarkdownService"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "demo.service.HtmlSanitizerService",
+      "allDeclaredFields": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "demo.service.MarkdownService",
+      "allDeclaredFields": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "demo.service.HtmlSanitizerService"
+          ]
+        }
+      ]
+    },
+    {
       "type": "demo.web.AddEntryAfterTo",
       "fields": [
         {
@@ -495,6 +529,7 @@
         {
           "name": "index",
           "parameterTypes": [
+            "java.nio.file.Path",
             "org.springframework.ui.Model"
           ]
         },
@@ -538,40 +573,6 @@
         {
           "name": "id",
           "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "type": "demo.service.HtmlConverterService",
-      "allDeclaredFields": true,
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
-            "demo.service.MarkdownService"
-          ]
-        }
-      ]
-    },
-    {
-      "type": "demo.service.HtmlSanitizerService",
-      "allDeclaredFields": true,
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": []
-        }
-      ]
-    },
-    {
-      "type": "demo.service.MarkdownService",
-      "allDeclaredFields": true,
-      "methods": [
-        {
-          "name": "<init>",
-          "parameterTypes": [
-            "demo.service.HtmlSanitizerService"
-          ]
         }
       ]
     },
@@ -4240,9 +4241,6 @@
       "glob": "demo"
     },
     {
-      "glob": "demo/rest/EditorController.class"
-    },
-    {
       "glob": "demo/service/HtmlConverterService.class"
     },
     {
@@ -4250,6 +4248,9 @@
     },
     {
       "glob": "demo/service/MarkdownService.class"
+    },
+    {
+      "glob": "demo/web/EditorController.class"
     },
     {
       "glob": "git.properties"

--- a/editor/src/main/resources/templates/index.html
+++ b/editor/src/main/resources/templates/index.html
@@ -33,7 +33,7 @@
 </head>
 <body>
 
-<div class="border-b bg-white/80 backdrop-blur">
+<div data-open class="border-b bg-white/80 backdrop-blur">
     <div class="mx-auto max-w-5xl px-4 py-2">
         <form id="playbook" class="flex items-center gap-2" method="get" th:action="@{/}">
             <label for="playbook-input" class="font-medium">Playbook:</label>

--- a/editor/src/main/resources/templates/index.html
+++ b/editor/src/main/resources/templates/index.html
@@ -35,14 +35,17 @@
 
 <div class="border-b bg-white/80 backdrop-blur">
     <div class="mx-auto max-w-5xl px-4 py-2">
-        <div id="playbook" class="flex items-center gap-2">
+        <form id="playbook" class="flex items-center gap-2" method="get" th:action="@{/}">
             <label for="playbook-input" class="font-medium">Playbook:</label>
             <input id="playbook-input"
+                   name="playbook"
                    type="text"
                    th:value="${playbook}"
                    class="flex-1 min-w-0 rounded border px-3 py-1.5"/>
-            <button class="rounded bg-blue-600 px-3 py-1.5 text-white hover:bg-blue-700">Open</button>
-        </div>
+            <button type="submit"
+                    name="open"
+                    class="rounded bg-blue-600 px-3 py-1.5 text-white hover:bg-blue-700">Open</button>
+        </form>
 
         <div th:if="${warning}"
              id="warning"

--- a/editor/src/test/java/demo/EditorIT.java
+++ b/editor/src/test/java/demo/EditorIT.java
@@ -91,4 +91,38 @@ class EditorIT {
                     .assertRowTextContains("DisplayFile");
         }
     }
+
+    @Test
+    void openPlaybookFromPath() {
+        try (EditorWebApplication editor = EditorWebApplication.launch()) {
+            editor.openEditorPage()
+                    .setPlaybookPath("src/test/resources/fixtures/another-runbook.json")
+                    .clickOpenButton()
+                    .row(0)
+                    .waitForHeadingToBeVisible(HeadingLevel.H1)
+                    .assertTitleContains(HeadingLevel.H1, "Another Heading");
+
+            editor.assertNoWarning();
+        }
+    }
+
+    @Test
+    void showWarningWhenPlaybookDoesNotExist() {
+        try (EditorWebApplication editor = EditorWebApplication.launch()) {
+            editor.openEditorPage()
+                    .setPlaybookPath("src/test/resources/fixtures/missing.json")
+                    .clickOpenButton()
+                    .assertWarningContains("does not exist");
+        }
+    }
+
+    @Test
+    void showWarningWhenFileIsNotAPlaybook() {
+        try (EditorWebApplication editor = EditorWebApplication.launch()) {
+            editor.openEditorPage()
+                    .setPlaybookPath("src/test/resources/fixtures/not-a-playbook.txt")
+                    .clickOpenButton()
+                    .assertWarningContains("not a playbook");
+        }
+    }
 }

--- a/editor/src/test/java/demo/EditorIT.java
+++ b/editor/src/test/java/demo/EditorIT.java
@@ -96,13 +96,13 @@ class EditorIT {
     void openPlaybookFromPath() {
         try (EditorWebApplication editor = EditorWebApplication.launch()) {
             editor.openEditorPage()
+                    .open()
                     .setPlaybookPath("src/test/resources/fixtures/another-runbook.json")
+                    .assertNoWarning()
                     .clickOpenButton()
                     .row(0)
                     .waitForHeadingToBeVisible(HeadingLevel.H1)
                     .assertTitleContains(HeadingLevel.H1, "Another Heading");
-
-            editor.assertNoWarning();
         }
     }
 
@@ -110,6 +110,7 @@ class EditorIT {
     void showWarningWhenPlaybookDoesNotExist() {
         try (EditorWebApplication editor = EditorWebApplication.launch()) {
             editor.openEditorPage()
+                    .open()
                     .setPlaybookPath("src/test/resources/fixtures/missing.json")
                     .clickOpenButton()
                     .assertWarningContains("does not exist");
@@ -120,6 +121,7 @@ class EditorIT {
     void showWarningWhenFileIsNotAPlaybook() {
         try (EditorWebApplication editor = EditorWebApplication.launch()) {
             editor.openEditorPage()
+                    .open()
                     .setPlaybookPath("src/test/resources/fixtures/not-a-playbook.txt")
                     .clickOpenButton()
                     .assertWarningContains("not a playbook");

--- a/editor/src/test/java/demo/EditorWebApplication.java
+++ b/editor/src/test/java/demo/EditorWebApplication.java
@@ -25,22 +25,20 @@ import java.util.function.Supplier;
 import static org.openqa.selenium.support.ui.ExpectedConditions.textToBePresentInElement;
 import static org.openqa.selenium.support.ui.ExpectedConditions.textToBePresentInElementValue;
 
-public class EditorWebApplication implements AutoCloseable {
+public class EditorWebApplication implements AutoCloseable, EditorWebApplication.WebContainer {
 
     private final int port;
     private final WebDriver driver;
     private Process process;
 
     public static EditorWebApplication launch() {
+        return launch(Path.of("src", "test", "resources", "fixtures", "sw-runbook.json"));
+    }
+
+    public static EditorWebApplication launch(final Path playbook) {
         final Path executable = Path.of("./target/swe");
         if (!Files.isExecutable(executable)) {
             throw new RuntimeException("The native executable '" + executable + "' is missing. Please make sure to build the native executable is built before running the functional tests.");
-        }
-
-        /* TODO: In the future we need to allow non existing files to be passed and show the error on the page */
-        final Path playbook = Path.of("src", "test", "resources", "fixtures", "sw-runbook.json");
-        if (!Files.exists(playbook)) {
-            throw new RuntimeException("The playbook path (" + playbook + ") does not exists");
         }
 
         try {
@@ -77,6 +75,32 @@ public class EditorWebApplication implements AutoCloseable {
 
     public EditorWebApplication openEditorPage() {
         driver.get("http://localhost:%d/".formatted(port));
+        return this;
+    }
+
+    private static final By PLAYBOOK_INPUT = By.cssSelector("#playbook-input");
+    private static final By OPEN_BUTTON = By.cssSelector("button[name=open]");
+    private static final By WARNING = By.cssSelector("#warning");
+
+    public EditorWebApplication setPlaybookPath(final String path) {
+        setInputValue(PLAYBOOK_INPUT, path);
+        return this;
+    }
+
+    public EditorWebApplication clickOpenButton() {
+        clickOn(OPEN_BUTTON);
+        return this;
+    }
+
+    public EditorWebApplication assertWarningContains(final String expected) {
+        assertElementTextContains(findElement(WARNING), expected);
+        return this;
+    }
+
+    public EditorWebApplication assertNoWarning() {
+        if (!driver.findElements(WARNING).isEmpty()) {
+            throw new AssertionError("Warning is visible");
+        }
         return this;
     }
 
@@ -347,5 +371,15 @@ public class EditorWebApplication implements AutoCloseable {
         WebElement element();
 
         WebDriver driver();
+    }
+
+    @Override
+    public WebElement element() {
+        return driver.findElement(By.tagName("body"));
+    }
+
+    @Override
+    public WebDriver driver() {
+        return driver;
     }
 }

--- a/editor/src/test/resources/fixtures/another-runbook.json
+++ b/editor/src/test/resources/fixtures/another-runbook.json
@@ -1,0 +1,9 @@
+{
+  "entries": [
+    {
+      "type": "Heading",
+      "level": "H1",
+      "title": "Another Heading"
+    }
+  ]
+}

--- a/editor/src/test/resources/fixtures/not-a-playbook.txt
+++ b/editor/src/test/resources/fixtures/not-a-playbook.txt
@@ -1,0 +1,1 @@
+This is not a playbook.


### PR DESCRIPTION
## Summary
- allow specifying a playbook path and opening it from the editor UI
- show warnings when a playbook path is missing or invalid
- add integration tests covering opening valid/invalid playbook paths

## Testing
- `mvn -q -pl editor -am verify` *(fails: Non-resolvable parent POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6895e7501ab0833082c0e4a7a4a9b5cb